### PR TITLE
Google login added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # composite-action-login-google
+
+This repository stores a [composite action](https://github.blog/changelog/2021-08-25-github-actions-reduce-duplication-with-action-composition/) used to set up Google Cloud Platform (GCP) login in order to release a helm chart using helmfile. 
+
+This means the action has to log into artifact registry as well as set up kubernetes context
+
+You can use this composite action as a step in your workflow like:
+```
+- id: google-login
+  if: ${{ steps.set-cloud-info.outputs.result == 'google' }}
+  uses: prefapp/composite-action-login-google@v1
+  with:
+    creds: ${{ env.GOOGLE_CREDENTIALS }}
+    cluster-name: ${{ env.CLUSTER_NAME }}
+    cluster-location: ${{ env.CLUSTER_LOCATION }}
+
+# ${{ steps.google-login.outputs.helmfile-creds }}
+```

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,36 @@
+name: 'Login google'
+description: 'Log into google (gcp) for a kubernetes deployment using helmfile'
+inputs:
+  creds:  
+    required: true
+  cluster-name:  
+    required: true
+  cluster-location:
+    required: true
+outputs:
+  helmfile-creds:
+    value: ${{ steps.set-helmfile.outputs.creds }}
+    
+runs:
+  using: "composite"
+  steps:
+
+    - id: google-auth
+      uses: 'google-github-actions/auth@v0'
+      with:
+        credentials_json: '${{ inputs.creds }}'
+
+    - name: Setup-Cloud-SDK
+      uses: 'google-github-actions/setup-gcloud@v0'
+
+    - id: get-credentials
+      uses: 'google-github-actions/get-gke-credentials@v0'
+      with:
+        cluster_name: ${{ inputs.cluster-name }}
+        location: ${{ inputs.cluster-location }}
+
+    - name: google-login
+      id: google-login
+      run: |
+        export HELMFILE_CREDS=$(gcloud auth application-default print-access-token)
+        echo "::set-output name=helmfile-creds::$(echo $HELMFILE_CREDS)"

--- a/action.yaml
+++ b/action.yaml
@@ -29,8 +29,7 @@ runs:
         cluster_name: ${{ inputs.cluster-name }}
         location: ${{ inputs.cluster-location }}
 
-    - name: google-login
-      id: google-login
+    - id: set-helmfile
       shell: bash
       run: |
         export HELMFILE_CREDS=$(gcloud auth application-default print-access-token)

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
     required: true
 outputs:
   helmfile-creds:
-    value: ${{ steps.set-helmfile.outputs.creds }}
+    value: ${{ steps.set-helmfile.outputs.helmfile-creds }}
     
 runs:
   using: "composite"

--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,7 @@ runs:
 
     - name: google-login
       id: google-login
+      shell: bash
       run: |
         export HELMFILE_CREDS=$(gcloud auth application-default print-access-token)
         echo "::set-output name=helmfile-creds::$(echo $HELMFILE_CREDS)"


### PR DESCRIPTION
Following: https://github.com/prefapp/demo-state/issues/358

This new action adds the prefapp ci/cd ecosystem the ability to easy login in a GKE and Google Registry (used in the demo-state workflows right now)

This composite actions adds to the already working:
- [composite-action-login-azure](https://github.com/prefapp/composite-action-login-azure)
- [composite-action-login-digitalocean](https://github.com/prefapp/composite-action-login-digitalocean)
- [composite-action-login-aws](https://github.com/prefapp/composite-action-login-aws)

The posibility to deploy to a kubernets cluster in a github action with a single point of authentication (this composite action).

Please read README.md to understand how to use it